### PR TITLE
Support floorplan card host resource loading

### DIFF
--- a/src/components/floorplan/lib/floorplan-config.ts
+++ b/src/components/floorplan/lib/floorplan-config.ts
@@ -15,8 +15,9 @@ import {
 
 import {
   FloorplanSvgElementInfo,
-  FloorplanRuleInfo
+  FloorplanRuleInfo,
 } from './floorplan-info';
+import { LovelaceCardConfig } from '../../../lib/homeassistant/data/lovelace';
 
 export class FloorplanConfig {
   // Core features
@@ -35,6 +36,8 @@ export class FloorplanConfig {
   defaults!: FloorplanRuleConfig;
   image_mobile!: FloorplanImageConfig | string;
   functions!: string;
+
+  card_hosts?: FloorplanCardHostConfig[];
 
   // Experimental features
   pages!: string[];
@@ -128,6 +131,18 @@ export class FloorplanRuleConfig {
     | string
     | false;
   hover_info_filter!: string[];
+}
+
+export interface FloorplanCardResourceConfig {
+  type?: 'module' | 'js';
+  url: string;
+  cache?: boolean;
+}
+
+export interface FloorplanCardHostConfig {
+  container_id: string;
+  config?: LovelaceCardConfig;
+  resources?: FloorplanCardResourceConfig[];
 }
 
 export class FloorplanRuleEntityElementConfig {


### PR DESCRIPTION
## Summary
- allow card host definitions to include resource descriptors alongside Lovelace card configs
- add resource-loading helpers that inject module scripts once and reuse them per container
- ensure declarative hosts and the `floorplan.card_set` service await resource loading before creating cards

## Testing
- npm run lint *(fails: `.eslintrc.js` relies on CommonJS `module` definition)*

------
https://chatgpt.com/codex/tasks/task_e_68df7967b5fc83259cca8ed77dd54f65