### PR TITLE
docs: document cards overlays

### DIFF
--- a/docs/examples/cards/cards.css
+++ b/docs/examples/cards/cards.css
@@ -1,0 +1,20 @@
+.background {
+  fill: #f3f5f7;
+}
+
+.label {
+  font-family: 'Roboto', sans-serif;
+  font-size: 26px;
+  fill: #2c3e50;
+}
+
+.card-slot {
+  fill: rgba(9, 37, 64, 0.05);
+  stroke: rgba(9, 37, 64, 0.15);
+  stroke-width: 2px;
+}
+
+/* Hide the placeholder rectangle when a card replaces it */
+.card-slot.is-replaced {
+  opacity: 0;
+}

--- a/docs/examples/cards/cards.svg
+++ b/docs/examples/cards/cards.svg
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400">
+  <title>cards[] example layout</title>
+  <rect width="600" height="400" class="background" />
+  <g id="living-room">
+    <text x="40" y="60" class="label">Living room</text>
+    <rect id="living-room-card" x="40" y="80" width="240" height="220" rx="12" class="card-slot" />
+  </g>
+  <g id="status" transform="translate(320,0)">
+    <text x="0" y="60" class="label">Status overlay</text>
+    <rect id="status-card" x="0" y="80" width="240" height="120" rx="12" class="card-slot" />
+  </g>
+</svg>

--- a/docs/examples/cards/cards.yaml
+++ b/docs/examples/cards/cards.yaml
@@ -1,0 +1,66 @@
+image: /local/floorplan/examples/cards/cards.svg
+stylesheet: /local/floorplan/examples/cards/cards.css
+
+cards:
+  - id: living_room_card
+    element: '#living-room-card'
+    mode: replace
+    pointer_events: passthrough
+    card:
+      type: thermostat
+      entity: climate.living_room
+    variants:
+      panel:
+        pointer_events: capture
+      maintenance:
+        card:
+          type: custom:repair-status-card
+          entity: climate.living_room
+
+  - id: status_card
+    element: '#status-card'
+    mode: overlay
+    pointer_events: capture
+    card:
+      type: entities
+      title: Climate overview
+      entities:
+        - sensor.living_room_temperature
+        - sensor.living_room_humidity
+        - binary_sensor.hvac_alert
+
+rules:
+  - element: '#living-room-card'
+    tap_action:
+      action: call-service
+      service: floorplan.execute
+      service_data:
+        swap_living_room_card: |
+          >
+          const swapTo = {
+            service: 'floorplan.card_set',
+            service_data: {
+              container_id: 'living_room_card',
+              config: {
+                type: 'entities',
+                title: 'Temporary climate snapshot',
+                entities: [
+                  'sensor.living_room_temperature',
+                  'sensor.living_room_humidity',
+                  'sensor.living_room_heating_demand'
+                ]
+              }
+            }
+          };
+          const swapBack = {
+            service: 'floorplan.card_set',
+            service_data: {
+              container_id: 'living_room_card',
+              config: {
+                type: 'thermostat',
+                entity: 'climate.living_room'
+              }
+            }
+          };
+          this.action('call-service', swapTo);
+          setTimeout(() => this.action('call-service', swapBack), 15000);


### PR DESCRIPTION
## Summary
- document the new `cards[]` configuration options, including mode handling, pointer events, variants, runtime swaps, and migration guidance
- add SVG, CSS, and YAML example assets that show replacing a placeholder rectangle with a thermostat card and swapping cards at runtime

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68df796599e08325ab15d793689a9d4a