### PR TITLE
Support cards config alias for floorplan card hosts

### DIFF
--- a/src/components/floorplan/floorplan-element.ts
+++ b/src/components/floorplan/floorplan-element.ts
@@ -1378,13 +1378,15 @@ export class FloorplanElement extends LitElement {
     svg: SVGGraphicsElement,
     config: FloorplanConfig
   ): void {
-    if (!config.card_hosts?.length) {
+    const cardHosts = config.cards ?? config.card_hosts;
+
+    if (!cardHosts?.length) {
       return;
     }
 
     const pageId = (config as FloorplanPageConfig).page_id;
 
-    for (const hostConfig of config.card_hosts) {
+    for (const hostConfig of cardHosts) {
       const targetElement = this.resolveCardHostTarget(svg, hostConfig);
       if (!targetElement) {
         this.logWarning(
@@ -2304,12 +2306,13 @@ export class FloorplanElement extends LitElement {
 
     const hasPages = Array.isArray(config.pages) && config.pages.length > 0;
     const hasRules = Array.isArray(config.rules) && config.rules.length > 0;
-    const hasCards = Array.isArray(config.cards) && config.cards.length > 0;
+    const cardHosts = config.cards ?? config.card_hosts;
+    const hasCards = Array.isArray(cardHosts) && cardHosts.length > 0;
 
     if (!hasPages && !hasRules && !hasCards) {
       this.logWarning(
         'CONFIG',
-        `Cannot find 'pages', 'rules', or 'cards' in floorplan configuration`
+        `Cannot find 'pages', 'rules', 'cards', or 'card_hosts' in floorplan configuration`
       );
       //isValid = false;
     } else {
@@ -2325,7 +2328,7 @@ export class FloorplanElement extends LitElement {
         if (!hasRules && !hasCards) {
           this.logWarning(
             'CONFIG',
-            `Cannot find 'rules' or 'cards' in floorplan configuration`
+            `Cannot find 'rules', 'cards', or 'card_hosts' in floorplan configuration`
           );
           //isValid = false;
         }

--- a/src/components/floorplan/lib/floorplan-config.ts
+++ b/src/components/floorplan/lib/floorplan-config.ts
@@ -27,6 +27,9 @@ export class FloorplanConfig {
   log_level!: string;
   console_log_level!: string;
   rules!: FloorplanRuleConfig[];
+  /**
+   * @deprecated Use `cards` instead.
+   */
   card_hosts?: FloorplanCardHostConfig[];
 
   // Optional features
@@ -38,7 +41,7 @@ export class FloorplanConfig {
   defaults!: FloorplanRuleConfig;
   image_mobile!: FloorplanImageConfig | string;
   functions!: string;
-  cards!: FloorplanCardHostConfig[];
+  cards?: FloorplanCardHostConfig[];
 
   // Experimental features
   pages!: string[];


### PR DESCRIPTION
## Summary
- allow floorplan card host initialization to read from the new `cards` field while honoring legacy `card_hosts`
- relax configuration validation to treat either field as satisfying the card presence requirement
- update `FloorplanConfig` typing to mark `cards` optional and document the `card_hosts` alias as deprecated

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e026e744d483259e2f5dc1822f2793