### PR TITLE
Remove legacy floorplan card definition types

### DIFF
--- a/src/components/floorplan/lib/floorplan-config.ts
+++ b/src/components/floorplan/lib/floorplan-config.ts
@@ -18,7 +18,6 @@ import {
   FloorplanSvgElementInfo,
   FloorplanRuleInfo
 } from './floorplan-info';
-import { LovelaceCardConfig } from '../../../lib/homeassistant/data/lovelace';
 
 export class FloorplanConfig {
   // Core features
@@ -71,24 +70,6 @@ export type FloorplanActionConfig =
   | NoActionConfig
   | CustomActionConfig
   | HoverInfoActionConfig;
-
-export interface FloorplanCardVariantConfig {
-  id: string;
-  config: LovelaceCardConfig;
-}
-
-export interface FloorplanCardDefinition {
-  id: string;
-  config: LovelaceCardConfig;
-  variants?: FloorplanCardVariantConfig[];
-}
-
-export interface FloorplanCardHostConfig {
-  container_id: string;
-  config?: LovelaceCardConfig;
-  definitions?: FloorplanCardDefinition[];
-  default_definition?: string;
-}
 
 export class FloorplanPageConfig extends FloorplanConfig {
   page_id!: string;

--- a/src/components/floorplan/lib/floorplan-info.ts
+++ b/src/components/floorplan/lib/floorplan-info.ts
@@ -4,8 +4,7 @@ import {
   FloorplanRuleConfig,
   FloorplanActionConfig,
   FloorplanCardHostConfig,
-  FloorplanCardDefinition,
-  FloorplanCardVariantConfig,
+  FloorplanCardHostVariantConfig,
 } from './floorplan-config';
 
 export class FloorplanPageInfo {
@@ -37,20 +36,12 @@ export class FloorplanRuleInfo {
   constructor(public rule: FloorplanRuleConfig) {}
 }
 
-export class FloorplanCardVariantInfo {
-  constructor(public config: FloorplanCardVariantConfig) {}
-}
-
-export class FloorplanCardDefinitionInfo {
-  variants: FloorplanCardVariantInfo[] = [];
-
-  constructor(public config: FloorplanCardDefinition) {}
-}
-
 export class FloorplanCardHostInfo {
-  definitions: FloorplanCardDefinitionInfo[] = [];
+  variants: FloorplanCardHostVariantConfig[] = [];
 
-  constructor(public config: FloorplanCardHostConfig) {}
+  constructor(public config: FloorplanCardHostConfig) {
+    this.variants = config.variants ?? [];
+  }
 }
 
 export class FloorplanEntityInfo {


### PR DESCRIPTION
## Summary
- remove the legacy FloorplanCardDefinition/FloorplanCardHostConfig schema so only the new cards[] host schema remains
- streamline floorplan info helpers to align with the new card host variant structure

## Testing
- npm run build *(fails: existing TypeScript and terser errors remain, but duplicate identifier issue is gone)*

------
https://chatgpt.com/codex/tasks/task_e_68e026afc364832580f46cb208516d37