### PR TITLE
Normalize card host targets and add regression test

### DIFF
--- a/src/components/floorplan/lib/floorplan-config.ts
+++ b/src/components/floorplan/lib/floorplan-config.ts
@@ -183,7 +183,8 @@ export interface FloorplanCardHostVariantConfig
 export interface FloorplanCardHostConfig
   extends FloorplanCardHostStateConfig {
   id?: string;
-  target: string;
+  target?: string;
+  element?: string;
   container_id?: string;
   entities?: string[];
   variants?: FloorplanCardHostVariantConfig[];


### PR DESCRIPTION
## Summary
- allow card host configs to accept an `element` alias by making the target optional and normalizing selectors during initialization
- warn when card host entries omit both selector properties so users receive actionable feedback
- add a regression test that loads the docs cards example and verifies element-driven hosts resolve

## Testing
- npm test -- --testPathPattern=floorplan-configuration

------
https://chatgpt.com/codex/tasks/task_e_68e026b358d88325926349de28dfcc09