### PR TITLE
Support overlay card host mode and pointer events

### DIFF
--- a/src/components/floorplan/floorplan-element.ts
+++ b/src/components/floorplan/floorplan-element.ts
@@ -68,6 +68,8 @@ interface FloorplanCardEntry {
 interface FloorplanCardHostAutoState {
   config?: LovelaceCardConfig;
   visible?: boolean;
+  pointerEvents?: string;
+  mode?: 'replace' | 'overlay';
 }
 
 interface FloorplanCardHostInternal {
@@ -83,6 +85,7 @@ interface FloorplanCardHostInternal {
   isForeignObjectManaged: boolean;
   autoState?: FloorplanCardHostAutoState;
   currentVisible?: boolean;
+  currentPointerEvents?: string;
 }
 
 declare let NAME: string;
@@ -1129,6 +1132,25 @@ export class FloorplanElement extends LitElement {
       );
     }
 
+    const mode = hostConfig.mode ?? 'replace';
+
+    if (mode === 'overlay') {
+      const parent = target.parentNode;
+      if (parent) {
+        const wrapper = document.createElementNS(
+          'http://www.w3.org/2000/svg',
+          'g'
+        );
+        (wrapper as SVGGraphicsElement).dataset.floorplanCardHostWrapper = 'managed';
+        parent.replaceChild(wrapper, target);
+        wrapper.appendChild(target);
+        wrapper.appendChild(foreignObject);
+
+        foreignObject.dataset.floorplanCardHost = 'managed';
+        return foreignObject;
+      }
+    }
+
     const replaced = this.replaceElement(target, foreignObject);
     replaced.dataset.floorplanCardHost = 'managed';
     return replaced;
@@ -1191,6 +1213,14 @@ export class FloorplanElement extends LitElement {
       state.visible = config.options.visible;
     }
 
+    if (config.pointer_events !== undefined) {
+      state.pointerEvents = config.pointer_events;
+    }
+
+    if (config.mode) {
+      state.mode = config.mode;
+    }
+
     return state;
   }
 
@@ -1214,6 +1244,14 @@ export class FloorplanElement extends LitElement {
         state.visible = variant.visible;
       } else if (variant.options?.visible !== undefined) {
         state.visible = variant.options.visible;
+      }
+
+      if (variant.pointer_events !== undefined) {
+        state.pointerEvents = variant.pointer_events;
+      }
+
+      if (variant.mode) {
+        state.mode = variant.mode;
       }
     }
 
@@ -1363,6 +1401,20 @@ export class FloorplanElement extends LitElement {
     host.container.style.display = visible ? '' : 'none';
   }
 
+  private applyCardHostPointerEvents(
+    host: FloorplanCardHostInternal,
+    pointerEvents?: string
+  ): void {
+    const value = pointerEvents ?? 'auto';
+
+    if (host.currentPointerEvents === value) {
+      return;
+    }
+
+    host.currentPointerEvents = value;
+    host.container.style.pointerEvents = value;
+  }
+
   private findCardHostByContainerId(
     containerId: string
   ): FloorplanCardHostInternal | undefined {
@@ -1423,6 +1475,8 @@ export class FloorplanElement extends LitElement {
         hostConfig.id ??
         (pageId ? `${pageId}-${containerId}` : containerId);
 
+      const baseState = this.buildCardHostBaseState(hostConfig);
+
       const container = this.ensureCardHostContainerElement(
         foreignObject,
         hostId
@@ -1449,7 +1503,8 @@ export class FloorplanElement extends LitElement {
       this._cardHostContainers.set(containerId, hostId);
       this._cards.set(containerId, { container, hostId });
 
-      const baseState = this.buildCardHostBaseState(hostConfig);
+      this.applyCardHostPointerEvents(hostEntry, baseState.pointerEvents);
+
       if (baseState.visible !== undefined) {
         this.applyCardHostVisibility(hostEntry, baseState.visible);
       }
@@ -1459,13 +1514,16 @@ export class FloorplanElement extends LitElement {
           source: hostEntry.overrideSource,
           visible: baseState.visible,
         });
-        hostEntry.autoState = {
-          config: baseState.cardConfig
-            ? this.cloneCardConfig(baseState.cardConfig)
-            : undefined,
-          visible: baseState.visible,
-        };
       }
+
+      hostEntry.autoState = {
+        config: baseState.cardConfig
+          ? this.cloneCardConfig(baseState.cardConfig)
+          : undefined,
+        visible: baseState.visible,
+        pointerEvents: baseState.pointerEvents,
+        mode: baseState.mode,
+      };
     }
   }
 
@@ -1502,9 +1560,16 @@ export class FloorplanElement extends LitElement {
       const visibilityChanged =
         state.visible !== undefined &&
         state.visible !== host.currentVisible;
+      const desiredPointerEvents = state.pointerEvents ?? 'auto';
+      const currentPointerEvents = host.currentPointerEvents ?? 'auto';
+      const pointerEventsChanged = desiredPointerEvents !== currentPointerEvents;
 
-      if (!cardChanged && !visibilityChanged) {
+      if (!cardChanged && !visibilityChanged && !pointerEventsChanged) {
         continue;
+      }
+
+      if (pointerEventsChanged) {
+        this.applyCardHostPointerEvents(host, state.pointerEvents);
       }
 
       host.autoState = {
@@ -1512,12 +1577,16 @@ export class FloorplanElement extends LitElement {
           ? this.cloneCardConfig(state.cardConfig)
           : undefined,
         visible: state.visible,
+        pointerEvents: state.pointerEvents,
+        mode: state.mode,
       };
 
-      await this.setCard(host.containerId, state.cardConfig, {
-        source: 'auto',
-        visible: state.visible,
-      });
+      if (cardChanged || visibilityChanged) {
+        await this.setCard(host.containerId, state.cardConfig, {
+          source: 'auto',
+          visible: state.visible,
+        });
+      }
     }
   }
 

--- a/src/components/floorplan/lib/floorplan-config.ts
+++ b/src/components/floorplan/lib/floorplan-config.ts
@@ -161,6 +161,8 @@ export interface FloorplanCardHostStateConfig {
   card?: LovelaceCardConfig;
   visible?: boolean;
   options?: FloorplanCardSetOptions;
+  mode?: 'replace' | 'overlay';
+  pointer_events?: string;
 }
 
 export interface FloorplanCardHostConditionConfig {

--- a/tests/jest/tests/floorplan-card-hosts.test.ts
+++ b/tests/jest/tests/floorplan-card-hosts.test.ts
@@ -1,0 +1,111 @@
+import '@testing-library/jest-dom';
+import { FloorplanElement } from '../../../src/components/floorplan/floorplan-element';
+import { FloorplanCardHostConfig } from '../../../src/components/floorplan/lib/floorplan-config';
+
+describe('Floorplan card hosts', () => {
+  const svgNamespace = 'http://www.w3.org/2000/svg';
+
+  beforeAll(() => {
+    const foreignObjectCtor = (global as any).SVGForeignObjectElement;
+    if (!foreignObjectCtor) {
+      (global as any).SVGForeignObjectElement = window.SVGElement;
+    }
+  });
+
+  function createSvgWithTarget(id: string): {
+    svg: SVGGraphicsElement;
+    target: SVGGraphicsElement;
+  } {
+    const svg = document.createElementNS(svgNamespace, 'svg') as SVGGraphicsElement;
+    const target = document.createElementNS(svgNamespace, 'rect') as SVGGraphicsElement;
+    target.id = id;
+    Object.defineProperty(target, 'getBBox', {
+      configurable: true,
+      value: () => ({ x: 0, y: 0, width: 100, height: 50 } as DOMRect),
+    });
+    svg.appendChild(target);
+    document.body.appendChild(svg);
+    return { svg, target };
+  }
+
+  afterEach(() => {
+    document.body.querySelectorAll('svg').forEach((element) => element.remove());
+  });
+
+  it('keeps the original target when overlaying and applies pointer events', () => {
+    const { svg, target } = createSvgWithTarget('overlay-target');
+
+    const overlayHost: FloorplanCardHostConfig = {
+      target: '#overlay-target',
+      mode: 'overlay',
+      pointer_events: 'none',
+    };
+
+    const element = new FloorplanElement();
+    const internal = element as any;
+    internal.config = { card_hosts: [overlayHost] };
+
+    internal.initCardHosts(svg, internal.config);
+
+    const hosts = Array.from(internal._cardHosts.values());
+    expect(hosts).toHaveLength(1);
+    const host = hosts[0];
+
+    expect(svg.querySelector('#overlay-target')).toBe(target);
+    expect(target.parentElement).not.toBeNull();
+    expect(target.parentElement?.contains(host.foreignObject)).toBe(true);
+    expect(host.container.style.pointerEvents).toBe('none');
+  });
+
+  it('updates pointer events for replace mode variants without removing the original foreign object', async () => {
+    const entityId = 'sensor.demo';
+    const { svg } = createSvgWithTarget('replace-target');
+
+    const replaceHost: FloorplanCardHostConfig = {
+      target: '#replace-target',
+      variants: [
+        {
+          pointer_events: 'none',
+          conditions: [
+            {
+              entity: entityId,
+              state: 'active',
+            },
+          ],
+        },
+      ],
+    };
+
+    const element = new FloorplanElement();
+    const internal = element as any;
+    internal.config = { card_hosts: [replaceHost] };
+    element.hass = {
+      states: {
+        [entityId]: {
+          entity_id: entityId,
+          state: 'inactive',
+          attributes: {},
+          context: {},
+        },
+      },
+    } as any;
+
+    internal.initCardHosts(svg, internal.config);
+
+    const hosts = Array.from(internal._cardHosts.values());
+    expect(hosts).toHaveLength(1);
+    const host = hosts[0];
+
+    expect(host.foreignObject.id).toBe('replace-target');
+    expect(svg.querySelector('#replace-target')).toBe(host.foreignObject);
+    expect(host.container.style.pointerEvents).toBe('auto');
+
+    element.hass.states[entityId].state = 'active';
+    await internal.updateCardHosts(new Set([entityId]));
+    expect(host.container.style.pointerEvents).toBe('none');
+
+    element.hass.states[entityId].state = 'inactive';
+    await internal.updateCardHosts(new Set([entityId]));
+    expect(host.container.style.pointerEvents).toBe('auto');
+  });
+});


### PR DESCRIPTION
## Summary
- add optional mode and pointer_events fields to card host state configuration and variants
- update floorplan card host initialization and updates to support overlay mode and pointer event changes
- add jest coverage exercising overlay wrapping and pointer event toggling

## Testing
- npm test -- --runTestsByPath tests/jest/tests/floorplan-card-hosts.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e026ba94448325b234328f35ddca6f