### PR TITLE
Support declarative floorplan card hosts

### DIFF
--- a/src/components/floorplan/lib/floorplan-info.ts
+++ b/src/components/floorplan/lib/floorplan-info.ts
@@ -40,7 +40,20 @@ export class FloorplanCardHostInfo {
   variants: FloorplanCardHostVariantConfig[] = [];
 
   constructor(public config: FloorplanCardHostConfig) {
-    this.variants = config.variants ?? [];
+    const variants = config.variants;
+
+    if (!variants) {
+      this.variants = [];
+    } else if (Array.isArray(variants)) {
+      this.variants = variants;
+    } else {
+      this.variants = Object.entries(variants).map(
+        ([variantId, variantConfig]) => ({
+          id: variantConfig.id ?? variantId,
+          ...variantConfig,
+        })
+      );
+    }
   }
 }
 

--- a/tests/jest/tests/floorplan-card-hosts.test.ts
+++ b/tests/jest/tests/floorplan-card-hosts.test.ts
@@ -47,9 +47,9 @@ describe('Floorplan card hosts', () => {
 
     internal.initCardHosts(svg, internal.config);
 
-    const hosts = Array.from(internal._cardHosts.values());
+    const hosts: any[] = Array.from(internal._cardHosts.values());
     expect(hosts).toHaveLength(1);
-    const host = hosts[0];
+    const host = hosts[0] as any;
 
     expect(svg.querySelector('#overlay-target')).toBe(target);
     expect(target.parentElement).not.toBeNull();
@@ -92,9 +92,9 @@ describe('Floorplan card hosts', () => {
 
     internal.initCardHosts(svg, internal.config);
 
-    const hosts = Array.from(internal._cardHosts.values());
+    const hosts: any[] = Array.from(internal._cardHosts.values());
     expect(hosts).toHaveLength(1);
-    const host = hosts[0];
+    const host = hosts[0] as any;
 
     expect(host.foreignObject.id).toBe('replace-target');
     expect(svg.querySelector('#replace-target')).toBe(host.foreignObject);
@@ -107,5 +107,33 @@ describe('Floorplan card hosts', () => {
     element.hass.states[entityId].state = 'inactive';
     await internal.updateCardHosts(new Set([entityId]));
     expect(host.container.style.pointerEvents).toBe('auto');
+  });
+
+  it('supports declarative cards with pointer passthrough', () => {
+    const { svg, target } = createSvgWithTarget('passthrough-target');
+
+    const config = {
+      cards: [
+        {
+          target: '#passthrough-target',
+          pointer_events: 'passthrough',
+          mode: 'overlay',
+        },
+      ],
+    };
+
+    const element = new FloorplanElement();
+    const internal = element as any;
+    internal.config = config;
+
+    internal.initCardHosts(svg, config);
+
+    const hosts: any[] = Array.from(internal._cardHosts.values());
+    expect(hosts).toHaveLength(1);
+    const host = hosts[0] as any;
+
+    expect(target.parentElement?.contains(host.foreignObject)).toBe(true);
+    expect(host.container.style.pointerEvents).toBe('none');
+    expect(host.autoState.pointerEvents).toBe('passthrough');
   });
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -114,6 +114,10 @@ export default (env) => {
       minimizer: [
         new TerserPlugin({
           extractComments: false,
+          include: /floorplan\.js$/,
+          terserOptions: {
+            module: true,
+          },
         }),
       ],
     },


### PR DESCRIPTION
## Summary
- allow floorplan-element to ingest the new `cards` config, normalize card host state, and reuse embedded card instances
- normalize pointer events including passthrough handling so overlays can keep floorplan gestures while tracking visibility and config changes
- convert card host variants declared as objects into arrays, expand unit tests, and limit terser minification to the main bundle to restore production builds

## Testing
- npm run build
- npm test -- --runTestsByPath tests/jest/tests/floorplan-card-hosts.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68e0ad9a609083258edc0f59b5d68adf